### PR TITLE
Adding a working pre-commit hook script

### DIFF
--- a/setup/pre-commit
+++ b/setup/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+find $(git status --porcelain | awk '{print $2}' | paste -s -d' ' -) -size +5M | sed 's|^\./||' | sort -u >.gitignore-largefiles
+
+cat .gitignore-largefiles >>.gitignore
+
+git diff --quiet --exit-code .gitignore
+exit_status=$?
+
+if [ $exit_status -eq 1 ]; then
+   set +e
+   for i in $(cat .gitignore-largefiles); do
+       set +e
+       echo "omitting large file: $i"
+       git rm --cached $i
+   done
+   git add .gitignore
+   # no need to commit explicitly
+fi
+
+rm -f .gitignore-largefiles
+

--- a/setup/pre-commit
+++ b/setup/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-find $(git status --porcelain | awk '{print $2}' | paste -s -d' ' -) -size +5M | sed 's|^\./||' | sort -u >.gitignore-largefiles
+find $(git status --porcelain | awk '{print $2}' | paste -s -d' ' -) -size +45M | sed 's|^\./||' | sort -u >.gitignore-largefiles
 
 cat .gitignore-largefiles >>.gitignore
 
@@ -11,7 +11,7 @@ if [ $exit_status -eq 1 ]; then
    set +e
    for i in $(cat .gitignore-largefiles); do
        set +e
-       echo "omitting large file: $i"
+       printf "omitting large file: "
        git rm --cached $i
    done
    git add .gitignore


### PR DESCRIPTION
This is a modified version of the pre-commit `.git/hooks` script we discussed on Slack. 

  1) In the `find` statement, changed `cut -f3 -d' '` to `awk '{print $2}'` to be flexible to lines with leading spaces.

  2) In the `find` statement, bumped up the maximum file-size limit to 45 MB, just below Git's 50 MB limit.

  3) Added `--quiet` flag to `git diff` line to silence reported diff lines.

  4) The explicit `git commit .gitignore ...` line is unnecessary, as the downstream action is an automated commit, allowing only the permitted changes (including those in `.gitignore`). Actually, if the line is included, Git emits an error: `fatal: cannot lock ref 'HEAD': reference already exists`
 
-Jessen